### PR TITLE
Update make_output_timeless date regex for compatibility with CGI.pm >= 4.58

### DIFF
--- a/t/03_destination.t
+++ b/t/03_destination.t
@@ -208,7 +208,7 @@ subtest 'Redirection failure [Basic]' => sub {
 
 sub make_output_timeless {
         my $output = shift;
-        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D(?:\%3D)?\; path=\/\; expires=\w{3},\s\d{2}\-\w{3}\-\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
+        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D(?:\%3D)?\; path=\/\; expires=\w{3},\s\d{2}(?:\-|\s)\w{3}(?:\-|\s)\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
         $output =~ s/^(Expires:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Expires$2/m;
         $output =~ s/^(Date:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Date$2/m;
         #$output =~ s/\r//g;

--- a/t/03_login_box_other.t
+++ b/t/03_login_box_other.t
@@ -179,7 +179,7 @@ subtest 'grey II' => sub {
 
 sub make_output_timeless {
         my $output = shift;
-        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}\-\w{3}\-\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
+        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}(?:\-|\s)\w{3}(?:\-|\s)\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
         $output =~ s/^(Expires:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Expires$2/m;
         $output =~ s/^(Date:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Date$2/m;
         #$output =~ s/\r//g;

--- a/t/03_missing_color.t
+++ b/t/03_missing_color.t
@@ -95,7 +95,7 @@ subtest 'No Base color' => sub {
 
 sub make_output_timeless {
         my $output = shift;
-        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}\-\w{3}\-\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
+        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}(?:\-|\s)\w{3}(?:\-|\s)\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
         $output =~ s/^(Expires:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Expires$2/m;
         $output =~ s/^(Date:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Date$2/m;
         #$output =~ s/\r//g;

--- a/t/70_action_dispatch.t
+++ b/t/70_action_dispatch.t
@@ -106,7 +106,7 @@ subtest 'successful login' => sub {
 
 sub make_output_timeless {
         my $output = shift;
-        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}\-\w{3}\-\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
+        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}(?:\-|\s)\w{3}(?:\-|\s)\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
         $output =~ s/^(Expires:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Expires$2/m;
         $output =~ s/^(Date:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Date$2/m;
         #$output =~ s/\r//g;

--- a/t/80_devpopup.t
+++ b/t/80_devpopup.t
@@ -108,7 +108,7 @@ subtest 'successful login' => sub {
 
 sub make_output_timeless {
         my $output = shift;
-        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}\-\w{3}\-\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
+        $output =~ s/^(Set-Cookie: CAPAUTH_DATA=\w+\%3D\%3D\; path=\/\; expires=\w{3},\s\d{2}(?:\-|\s)\w{3}(?:\-|\s)\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Set-Cookie: CAPAUTH_DATA=; path=\/; expires=;$2/m;
         $output =~ s/^(Expires:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Expires$2/m;
         $output =~ s/^(Date:\s\w{3},\s\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s\w{3})([\r\n\s]*)$/Date$2/m;
         #$output =~ s/\r//g;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
CGI-Application-Plugin-Authentication.
We thought you might be interested in it too.

    Description: Update make_output_timeless date regex
     libcgi-pm-perl changed the cookie expires date format in 4.58 from
     "DD-MON-YYY" to "DD MON YYYY". This patch changes the regex to match match
     both "\-" and "\s" in the corresponding positions in "make_output_timeless"
     subroutine definitions.
    Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1054973
    Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/libcgi-application-plugin-authentication-perl/+bug/2047961
    Author: Chris Peterson <chris.peterson@canonical.com>
    Reviewed-by: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-01-05
    
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcgi-application-plugin-authentication-perl/raw/master/debian/patches/update-date-regex.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
