### PR TITLE
Update basic_login_box reference for CGI.pm >=4.66

### DIFF
--- a/t/03_login_box_basic.t
+++ b/t/03_login_box_basic.t
@@ -62,6 +62,15 @@ my $cap_options =
 
 }
 
+sub contents {
+    my $file = shift;
+    my $fh = FileHandle->new;
+    $fh->open("<$file") || return ok( 0, "cannot open $file" );
+    $fh->binmode;
+    my $content = join '', (<$fh>);
+    return $content
+};
+
 subtest 'empty' => sub {
     plan tests => 14;
     my $cgiapp = TestAppAuthenticate->new;
@@ -74,7 +83,11 @@ subtest 'empty' => sub {
     isa_ok($display, 'CGI::Application::Plugin::Authentication::Display');
     isa_ok($display, 'CGI::Application::Plugin::Authentication::Display::Basic');
     is($display->login_title, 'Sign In', 'title');
-    ok_regression(sub {return $display->login_box}, 't/out/basic_login_box', 'login box');
+    ok(
+         $display->login_box eq contents('t/out/basic_login_box') ||
+         $display->login_box eq contents('t/out/basic_login_box_trailing_slash'),
+        'login box'
+    );
     is($display->logout_form, '', 'logout_form');
     is($display->is_authenticated, 0, 'is_authenticated');
     is($display->username, undef, 'username');

--- a/t/out/basic_login_box_trailing_slash
+++ b/t/out/basic_login_box_trailing_slash
@@ -1,0 +1,33 @@
+<form id="loginform" method="post" action="">
+  <div class="login">
+    <div class="login_header">
+      Sign In
+    </div>
+    <div class="login_content">
+      <ul class="message">
+<li>Please enter your username and password in the fields below.</li>
+      </ul>
+      <fieldset>
+        <label for="authen_loginfield" id="authen_loginfield_label" class="authen_label">User Name
+            <input id="authen_loginfield" class="authen_input" tabindex="1" type="text" name="authen_username" size="20" value="" />
+        </label>    
+        <label for="authen_passwordfield" id="authen_passwordfield_label" class="authen_label">Password
+            <input id="authen_passwordfield" class="authen_input" tabindex="2" type="password" name="authen_password" size="20" />
+        </label>
+        <label for="authen_rememberuserfield" id="authen_rememberuserfield_label" class="authen_label">Remember User Name
+    <input id="authen_rememberuserfield" class="authen_input" tabindex="3" type="checkbox" name="authen_rememberuser" value="1" />
+</label>
+
+      </fieldset>
+    </div>
+    <div class="login_footer">
+      <div class="buttons">
+        <input id="authen_loginbutton" tabindex="4" type="submit" name="authen_loginbutton" value="Sign In" class="button" />
+        
+        
+      </div>
+    </div>
+  </div>
+  <input type="hidden" name="destination" value="http://localhost/" />
+  <input type="hidden" name="rm" value="one" />
+</form>


### PR DESCRIPTION
In Ubuntu, I identified a regression with cgi-application-plugin-authentication due to the latest version of CGI.pm (4.66) changing behavior with trailing slashes in URLs [1]. According to the test suite, this was the only instance of this failure I could find. I plan to apply this as a patch in Ubuntu and forward it along to Debian as well. I thought you may be interested too.


[1] https://github.com/leejo/CGI.pm/commit/a5485b5f3b2b1cc85761b6781ff6660b4f377498